### PR TITLE
 fix: auction 종료된 경매 입찰 방어 로직 추가

### DIFF
--- a/uppick-auction-service/src/main/java/org/oneog/uppick/auction/domain/auction/command/service/component/BiddingProcessor.java
+++ b/uppick-auction-service/src/main/java/org/oneog/uppick/auction/domain/auction/command/service/component/BiddingProcessor.java
@@ -1,6 +1,7 @@
 package org.oneog.uppick.auction.domain.auction.command.service.component;
 
 import org.oneog.uppick.auction.domain.auction.command.entity.Auction;
+import org.oneog.uppick.auction.domain.auction.command.entity.AuctionStatus;
 import org.oneog.uppick.auction.domain.auction.command.entity.BiddingDetail;
 import org.oneog.uppick.auction.domain.auction.command.model.dto.request.AuctionBidRequest;
 import org.oneog.uppick.auction.domain.auction.command.model.dto.request.BiddingResultDto;
@@ -40,6 +41,11 @@ public class BiddingProcessor {
 			// 판매자 본인 입찰 방지
 			if (auction.getRegisterId().equals(memberId)) {
 				throw new BusinessException(AuctionErrorCode.CANNOT_BID_OWN_AUCTION);
+			}
+
+			//마감된 상품에 입찰 방지
+			if (auction.getStatus() != AuctionStatus.IN_PROGRESS) {
+				throw new BusinessException(AuctionErrorCode.AUCTION_ALREADY_ENDED);
 			}
 
 			long biddingPrice = request.getBiddingPrice();

--- a/uppick-auction-service/src/main/java/org/oneog/uppick/auction/domain/auction/common/exception/AuctionErrorCode.java
+++ b/uppick-auction-service/src/main/java/org/oneog/uppick/auction/domain/auction/common/exception/AuctionErrorCode.java
@@ -10,12 +10,12 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum AuctionErrorCode implements ErrorCode {
 
-	WRONG_BIDDING_PRICE(HttpStatus.BAD_REQUEST, "입찰가를 잘못 입력하셨습니다."), AUCTION_NOT_FOUND(HttpStatus.NOT_FOUND,
-		"해당 경매가 존재하지 않습니다."), CANNOT_BID_OWN_AUCTION(HttpStatus.BAD_REQUEST,
-			"본인의 판매 물품에는 입찰할 수 없습니다."), INSUFFICIENT_CREDIT(HttpStatus.BAD_REQUEST,
-				"보유한 크레딧보다 큰 금액을 입력할수 없습니다."), BID_FAILED_CAUSE_ACQUIRE_LOCK_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,
-					"입찰 처리 중 문제가 발생했습니다. 다시 시도해주세요.");
-
+	WRONG_BIDDING_PRICE(HttpStatus.BAD_REQUEST, "입찰가를 잘못 입력하셨습니다."),
+	AUCTION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 경매가 존재하지 않습니다."),
+	CANNOT_BID_OWN_AUCTION(HttpStatus.BAD_REQUEST, "본인의 판매 물품에는 입찰할 수 없습니다."),
+	INSUFFICIENT_CREDIT(HttpStatus.BAD_REQUEST, "보유한 크레딧보다 큰 금액을 입력할수 없습니다."),
+	BID_FAILED_CAUSE_ACQUIRE_LOCK_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "입찰 처리 중 문제가 발생했습니다. 다시 시도해주세요."),
+	AUCTION_ALREADY_ENDED(HttpStatus.BAD_REQUEST, "이미 종료된 경매입니다.");
 	private final HttpStatus status;
 	private final String message;
 


### PR DESCRIPTION
 

## 🔗 **연관된 이슈**

- Related to: #316 

---

## 📝 **작업 내용**
<!-- 작업 내용을 상세히 나열해주세요 -->
 - 경매 상태(FINISHED/EXPIRED) 검증으로 무효 입찰 차단
  - AuctionErrorCode.AUCTION_ALREADY_ENDED 추가
---

## 📸 **스크린샷 (Optional)**
<!-- 필요한 경우 스크린샷이나 GIF 등을 첨부해주세요. -->